### PR TITLE
Remove modules handling from release script.

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -21,11 +21,6 @@ if [ -z "$(git status --porcelain)" ]; then
   git pull origin dev
 
   VERSION=v$VERSION_NBR
-  go mod tidy
-
-  set +e
-  git commit -a -m "Releasing version $VERSION."
-  set -e
   git tag -a $VERSION -m "Version $VERSION"
   git push origin dev --tags
 


### PR DESCRIPTION
This is not a go module anymore, so remove modules step from release script.