### PR TITLE
Use temporary token for releasing instead of user personal access token.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,8 @@ jobs:
       - name: test
         run: echo "implement e2e tests"
   publish:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -25,8 +27,6 @@ jobs:
             idl/v1/agent.proto
             idl/v1/protocol.proto
             VERSION
-        env:
-          GITHUB_TOKEN: ${{ secrets.REPOSITORY_TOKEN }}
   merge:
     needs: e2e
     runs-on: ubuntu-latest


### PR DESCRIPTION
Use [recommended approach](https://docs.github.com/en/actions/reference/authentication-in-a-workflow#using-the-github_token-in-a-workflow) for handling GitHub tokens in actions.